### PR TITLE
Fix on pi

### DIFF
--- a/refbox/ui.py
+++ b/refbox/ui.py
@@ -13,7 +13,6 @@ _font_name = 'Consolas'
 def sized_frame(master, height, width):
     F = tk.Frame(master, height=height, width=width)
     F.pack_propagate(0)  # Don't shrink
-    F.pack()
     return F
 
 


### PR DESCRIPTION
Fixes this error:

```
 _tkinter.TclError: cannot use geometry manager pack inside . which
 already has slaves managed by grid
```