### PR TITLE
Set time to zero if under a minute and user subtracts a minute

### DIFF
--- a/refbox/ui.py
+++ b/refbox/ui.py
@@ -78,6 +78,8 @@ def EditTime(master, tb_offset, clock_at_pause, on_cancel, on_submit):
         x = clock_at_pause_var.get()
         if x - 60 >= 0:
             clock_at_pause_var.set(x - 60)
+        else:
+            clock_at_pause_var.set(0)
 
     def cancel_clicked():
         root.destroy()


### PR DESCRIPTION
This allows the user to end the half early. Before this patch,
you'd need to hit the minus-second button a bunch of times to get
the game clock down to zero. Now you can just hit the minus-minute
button and both minutes and seconds will zero out. Then hitting
SUBMIT will immediately ring the buzzer and end the half.